### PR TITLE
Don't fail silently when Python could not be installed

### DIFF
--- a/pythonbrew/commands/install.py
+++ b/pythonbrew/commands/install.py
@@ -3,6 +3,7 @@ from pythonbrew.basecommand import Command
 from pythonbrew.installer.pythoninstaller import PythonInstaller,\
     PythonInstallerMacOSX
 from pythonbrew.util import is_macosx
+from pythonbrew.log import logger
 
 class InstallCommand(Command):
     name = "install"
@@ -93,7 +94,8 @@ class InstallCommand(Command):
                 else:
                     p = PythonInstaller(arg, options)
                 p.install()
-            except:
-                continue
+            except Exception, e:
+                logger.error("Failed to install Python "+arg)
+                logger.error(str(e))
 
 InstallCommand()


### PR DESCRIPTION
I had a wrong http_proxy which was set, so python installation was failing silently.
This bugfix shows when exceptions happen during installation.
